### PR TITLE
Use path.join to concatenate paths

### DIFF
--- a/metalog.js
+++ b/metalog.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const { sep } = require('path');
+const path = require('path');
 const events = require('events');
 const common = require('@metarhia/common');
 const { WritableFileStream } = require('metastreams');
@@ -71,11 +71,11 @@ class Logger extends events.EventEmitter {
   // home <string> remove home paths from stack traces
   constructor(options) {
     super();
-    const { path, workerId = 0, Writable = WritableFileStream } = options;
+    const { workerId = 0, Writable = WritableFileStream } = options;
     const { writeInterval, writeBuffer, keepDays, home } = options;
     const { toFile, toStdout } = options;
     this.active = false;
-    this.path = path;
+    this.path = options.path;
     this.workerId = `W${workerId}`;
     this.Writable = Writable;
     this.writeInterval = writeInterval || 3000;
@@ -103,7 +103,8 @@ class Logger extends events.EventEmitter {
       return this;
     }
     const date = common.nowDate();
-    this.file = this.path + sep + date + '-' + this.workerId + '.log';
+    const fileName = date + '-' + this.workerId + '.log';
+    this.file = path.join(this.path, fileName);
     const now = new Date();
     const nextDate = new Date();
     nextDate.setUTCHours(0, 0, 0, 0);
@@ -185,7 +186,7 @@ class Logger extends events.EventEmitter {
         const fileTime = new Date(fileName.substring(0, 10)).getTime();
         const fileAge = Math.floor((time - fileTime) / DAY_MILLISECONDS);
         if (fileAge > 1 && fileAge > this.keepDays - 1) {
-          fs.unlink(this.path + sep + fileName, err => {
+          fs.unlink(path.join(this.path, fileName), err => {
             if (err) {
               process.stdout.write(`${err.stack}\n`);
               this.emit('error', err);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
