### PR TITLE
Use fs default factory instead of constructor from metastreams

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   },
   "dependencies": {
     "@metarhia/common": "^2.1.0",
-    "concolor": "^1.0.0",
-    "metastreams": "^0.1.2"
+    "concolor": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^7.15.0",


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
